### PR TITLE
Fixed `head::` error

### DIFF
--- a/Desktop/src/main.rs
+++ b/Desktop/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
 use dioxus::prelude::*;
+use document::Link;
 use tracing::Level;
 {% if router %}
 #[derive(Clone, Routable, Debug, PartialEq)]
@@ -63,7 +64,7 @@ fn App() -> Element {
     // Build cool things ✌️
 
     rsx! {
-        head::Link { rel: "stylesheet", href: asset!("./assets/main.css") }
+        Link { rel: "stylesheet", href: asset!("./assets/main.css") }
         img { src: asset!("./assets/header.svg"), id: "header" }
         div { id: "links",
             a { href: "https://dioxuslabs.com/learn/0.5/", "📚 Learn Dioxus" }

--- a/Fullstack/src/main.rs
+++ b/Fullstack/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
 use dioxus::prelude::*;
+use document::Link;
 use tracing::{Level, info};
 
 {% if router %}
@@ -69,7 +70,7 @@ fn App() -> Element {
     // Build cool things ✌️
 
     rsx! {
-        head::Link { rel: "stylesheet", href: asset!("./assets/main.css") }
+        Link { rel: "stylesheet", href: asset!("./assets/main.css") }
         img { src: asset!("./assets/header.svg"), id: "header" }
         div { id: "links",
             a { href: "https://dioxuslabs.com/learn/0.5/", "📚 Learn Dioxus" }

--- a/Liveview/src/main.rs
+++ b/Liveview/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
 use dioxus::prelude::*;
+use document::Link;
 use tracing::Level;
 {% if router %}
 #[derive(Clone, Routable, Debug, PartialEq)]
@@ -55,7 +56,7 @@ fn App() -> Element {
     // Build cool things ✌️
 
     rsx! {
-        head::Link { rel: "stylesheet", href: asset!("./assets/main.css") }
+        Link { rel: "stylesheet", href: asset!("./assets/main.css") }
         img { src: asset!("./assets/header.svg"), id: "header" }
         div { id: "links",
             a { href: "https://dioxuslabs.com/learn/0.5/", "📚 Learn Dioxus" }

--- a/TUI/src/main.rs
+++ b/TUI/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
 use dioxus::prelude::*;
+use document::Link;
 {% if router %}
 #[derive(Clone, Routable, Debug, PartialEq)]
 enum Route {

--- a/Web/src/main.rs
+++ b/Web/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
 use dioxus::prelude::*;
+use document::Link;
 use tracing::Level;
 {% if router %}
 #[derive(Clone, Routable, Debug, PartialEq)]
@@ -57,7 +58,7 @@ fn App() -> Element {
     // Build cool things ✌️
 
     rsx! {
-        head::Link { rel: "stylesheet", href: asset!("./assets/main.css") }
+        Link { rel: "stylesheet", href: asset!("./assets/main.css") }
         img { src: asset!("./assets/header.svg"), id: "header" }
         div { id: "links",
             a { target: "_blank", href: "https://dioxuslabs.com/learn/0.5/", "📚 Learn Dioxus" }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/337f9aa6-7664-4531-be7d-7322504c298a)

![image](https://github.com/user-attachments/assets/63756b5e-ebe5-42d1-b945-2474c7d602bd)

I removed the `head::` and the compilation succeeded.

It probably just needs to go to prelude, or the `head::` module should again have the `Link` included.